### PR TITLE
add-pre-commit-hook-and-semver

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+# .github/workflows/release-please.yml
+name: release-please
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: rust # Multiple release types are supported
+          default-branch: main

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 test_key*
+/node_modules
+yarn.lock

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit "$1"
+
+# follows the https://www.conventionalcommits.org/en/v1.0.0/ standard
+
+MESSAGE=$(cat $1)
+COMMITFORMAT="^(feat|fix|docs|style|refactor|test|chore|perf|other)(\((.*)\))?: #([0-9]+) (.*)$"
+
+if ! [[ "$MESSAGE" =~ $COMMITFORMAT ]]; then
+  echo "Your commit was rejected due to the commit message. Skipping..."
+  echo ""
+  echo "Please use the following format:"
+  echo "feat: #1234 feature example comment"
+  echo "fix(ui): #4321 bugfix example comment"
+  echo ""
+  echo "More details on COMMITS.md"
+  exit 1
+fi

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,15 @@
+{
+  "types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "hidden": true },
+    { "type": "docs", "hidden": true },
+    { "type": "style", "hidden": true },
+    { "type": "refactor", "hidden": true },
+    { "type": "perf", "hidden": true },
+    { "type": "test", "hidden": true }
+  ],
+  "commitUrlFormat": "https://github.com/mrlucciola/proof-of-stake/commit/{{hash}}",
+  "issueUrlFormat": "https://github.com/mrlucciola/proof-of-stake/issues/{{id}}",
+  "compareUrlFormat": "https://github.com/mrlucciola/proof-of-stake/compare/{{previousTag}}...{{currentTag}}"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 0.0.0 (2022-11-22)
+
+
+### Features
+
+* [#9](https://github.com/mrlucciola/proof-of-stake/issues/9) add commit hook and semver tools ([bef3d14](https://github.com/mrlucciola/proof-of-stake/commit/bef3d143275a89eed4e77c8051533ece510e1e18))
+* [#9](https://github.com/mrlucciola/proof-of-stake/issues/9) add semver config - Conventional Changelog Configuration ([5dbede0](https://github.com/mrlucciola/proof-of-stake/commit/5dbede0ab34624f2ff0edfcafa057687772c6dab))
+* add `does_txn_exist` method to `TxnPool` ([#7](https://github.com/mrlucciola/proof-of-stake/issues/7)) ([#8](https://github.com/mrlucciola/proof-of-stake/issues/8)) ([3b6558e](https://github.com/mrlucciola/proof-of-stake/commit/3b6558e83541e1f790cf5c48e1c429d7c102f3c6))
+* add `remove_txn` (4) ([#6](https://github.com/mrlucciola/proof-of-stake/issues/6)) ([74a76a8](https://github.com/mrlucciola/proof-of-stake/commit/74a76a8988e62406c79ed449c932d13f7d916de9))

--- a/package.json
+++ b/package.json
@@ -1,4 +1,24 @@
 {
+  "name": "proof-of-stake",
+  "version": "0.0.0",
+  "description": "Proof of stake implementation in Rust",
+  "main": "./",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mrlucciola/proof-of-stake.git"
+  },
+  "keywords": [
+    "PoS",
+    "Proof of Stake",
+    "Blockchain",
+    "Consensus"
+  ],
+  "author": "Rocco Lucciola (mrlucciola)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mrlucciola/proof-of-stake/issues"
+  },
+  "homepage": "https://github.com/mrlucciola/proof-of-stake#readme",
   "devDependencies": {
     "husky": "^8.0.0"
   },
@@ -7,6 +27,10 @@
     "@commitlint/config-conventional": "^17.3.0"
   },
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "release": "standard-version",
+    "release:patch": "standard-version --release-as patch",
+    "release:minor": "standard-version --release-as minor",
+    "release:major": "standard-version --release-as major"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "devDependencies": {
+    "husky": "^8.0.0"
+  },
+  "dependencies": {
+    "@commitlint/cli": "^17.3.0",
+    "@commitlint/config-conventional": "^17.3.0"
+  },
+  "scripts": {
+    "prepare": "husky install"
+  }
+}


### PR DESCRIPTION
Add pre commit hooks

Add logic for `commit-msg` hook to standardize commit messages.
Add logic to automate and standardize the PR flow through commit messages.

closes #9 