### PR TITLE
fix: #20 add simple create-block test for `blocks`

### DIFF
--- a/src/ledger/general.rs
+++ b/src/ledger/general.rs
@@ -1,3 +1,4 @@
 pub use secp256k1::ecdsa::Signature as SecpEcdsaSignature;
-// General reference regardless of which lib we use
-pub use secp256k1::PublicKey as PbKey;
+
+/// General reference regardless of which lib we use
+pub use secp256k1::{KeyPair as KP, PublicKey as PbKey, SecretKey as PvKey};

--- a/src/ledger/txn.rs
+++ b/src/ledger/txn.rs
@@ -70,7 +70,7 @@ impl Txn {
     /// Receives `Wallet` instance for signing.
     /// Uses `Txn::new()` assoc fxn. to construct the txn, and signs the txn with given wallet.
     pub fn new_signed(
-        wallet: Wallet,
+        wallet: &Wallet,
         pbkey_recv: PublicKey,
         amt_to_send: u128,
         txn_type: TxnType,
@@ -214,7 +214,7 @@ mod tests {
     fn create_new_signed_txn() {
         let (kp_send, kp_recv) = init_test_vars();
         let wallet_send = Wallet::new_from_kp(&kp_send);
-        let signed_txn = Txn::new_signed(wallet_send, kp_recv.public_key(), 100, TxnType::Transfer);
+        let signed_txn = Txn::new_signed(&wallet_send, kp_recv.public_key(), 100, TxnType::Transfer);
         let msg = signed_txn.hash();
 
         // get signature

--- a/src/ledger/txn_pool.rs
+++ b/src/ledger/txn_pool.rs
@@ -5,23 +5,23 @@ use std::collections::HashMap;
 use crate::ledger::txn::{Txn, TxnHash};
 // export types
 pub type Result<T> = std::result::Result<T, failure::Error>;
-pub type TxnMap = HashMap<TxnHash, Txn>;
+pub type PoolTxnMap = HashMap<TxnHash, Txn>;
 
 /// Data structure which holds all pending transactions
 #[derive(Debug, Serialize, Deserialize)]
 struct TxnPool {
     // Array of transactions
-    pub txns: TxnMap,
+    pub txns: PoolTxnMap,
 }
 impl TxnPool {
     /// Initializer for Transaction Pool
     ///
     /// Create a data structure which
     pub fn new() -> Self {
-        let new_thing = TxnMap::new();
+        let new_thing = PoolTxnMap::new();
 
         TxnPool {
-            txns: TxnMap::new(),
+            txns: PoolTxnMap::new(),
         }
     }
     /// Check if a transaction exists in the txn pool (#7)

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn example_create_and_sign_txn() -> (Txn, TxnSig) {
-    let wallet_main = Wallet::new_from_file(&"test_key.json".to_string());
+    let wallet_main = Wallet::new_from_file(&"test_key_send.json".to_string());
     let wallet_recv = Wallet::new_from_file(&"test_key_recv.json".to_string());
 
     // turn the raw txn into message

--- a/tests/blocks.rs
+++ b/tests/blocks.rs
@@ -1,0 +1,70 @@
+// imports
+// local
+use posbc::ledger::{
+    blocks::{Block, BlockTxnMap},
+    txn::{Txn, TxnHash, TxnType},
+};
+
+mod common;
+use common::{init_users, UsersInfo};
+
+fn create_sample_txn_map(num_txns: u8) -> BlockTxnMap {
+    let UsersInfo {
+        main: _,
+        send,
+        recv,
+    } = init_users();
+    let mut txn_map = BlockTxnMap::new();
+
+    if num_txns == 0 {
+        return txn_map;
+    }
+
+    // logic to create sample txn > add txn to map
+    for x in 0..num_txns {
+        let amt = (x as u128) + 1;
+        // create sample txn
+        let new_txn = Txn::new_signed(&send.wallet, recv.kp.public_key(), amt, TxnType::Transfer);
+
+        // add txn to map
+        txn_map.insert(new_txn.hash(), new_txn);
+    }
+
+    txn_map
+}
+
+#[test]
+fn create_empty_block() {
+    let UsersInfo {
+        main,
+        send: _,
+        recv: _,
+    } = init_users();
+
+    // create txn map
+    let txn_map: BlockTxnMap = create_sample_txn_map(0);
+    let genesis_blockhash: TxnHash = [0u8; 32];
+
+    // check if hashes line up
+    let new_block = Block::new(txn_map, main.kp.public_key(), genesis_blockhash, 0);
+    assert_eq!(new_block.hash(), new_block.hash, "{:?}", new_block.hash());
+    assert_eq!(new_block.hash(), "".as_bytes(), "{:?}", new_block.hash());
+}
+#[test]
+fn create_full_block() {
+    let UsersInfo {
+        main,
+        send: _,
+        recv: _,
+    } = init_users();
+
+    // create txn map
+    let txn_map: BlockTxnMap = create_sample_txn_map(3);
+    let genesis_blockhash: TxnHash = [0u8; 32];
+
+    let new_block = Block::new(txn_map, main.kp.public_key(), genesis_blockhash, 0);
+
+    // check if hashes line up
+    assert_eq!(new_block.hash(), new_block.hash, "{:?}", new_block.hash());
+    assert_eq!(new_block.hash(), "".as_bytes(), "{:?}", new_block.hash());
+}

--- a/tests/common/constants.rs
+++ b/tests/common/constants.rs
@@ -1,0 +1,4 @@
+// keys
+pub const KEYPAIR_MAIN: &str = "test_key_main.json";
+pub const KEYPAIR_SEND: &str = "test_key_send.json";
+pub const KEYPAIR_RECV: &str = "test_key_recv.json";

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,40 @@
+// import
+use secp256k1::Secp256k1;
+use std::{fs::File, io::BufReader};
+// local
+use posbc::ledger::{general::KP, wallet::Wallet};
+mod constants;
+use constants::*;
+
+fn create_keypair_from_file(filepath: &String) -> KP {
+    let f = File::open(filepath).unwrap();
+    let reader = BufReader::new(f);
+    let key_json: Vec<u8> = serde_json::from_reader(reader).unwrap();
+    let secp = Secp256k1::new();
+
+    let keypair = KP::from_seckey_slice(&secp, &key_json).unwrap();
+
+    keypair
+}
+
+pub struct UserInfo {
+    pub kp: KP,
+    pub wallet: Wallet,
+}
+fn get_user_info(key_str: &String) -> UserInfo {
+    let kp = create_keypair_from_file(key_str);
+    let wallet = Wallet::new_from_kp(&kp);
+    UserInfo { kp, wallet }
+}
+pub struct UsersInfo {
+    pub main: UserInfo,
+    pub send: UserInfo,
+    pub recv: UserInfo,
+}
+pub fn init_users() -> UsersInfo {
+    UsersInfo {
+        main: get_user_info(&KEYPAIR_MAIN.to_string()),
+        send: get_user_info(&KEYPAIR_SEND.to_string()),
+        recv: get_user_info(&KEYPAIR_RECV.to_string()),
+    }
+}


### PR DESCRIPTION
create integration test dir `tests/` on same level as `src/`.
We are able to now do both unit and integration testing outside of the library files.

close #20 