### PR TITLE
77 create node module in separate lib

### DIFF
--- a/docs/diagrams/Node Class.md
+++ b/docs/diagrams/Node Class.md
@@ -1,0 +1,7 @@
+# Node
+
+Node has a REST API to receive signed user transactions. Transactions must be signed if they want to be submitted to the txn pool.
+
+Node is responsible for peer to peer communications. It is a submodule within the node. P2P is used to communicate aross the pool of nodes.
+
+Node maintains the Blockchain. The Blockchain can create and add new blocks. Transactions are taken from the transaction pool and added to the block.

--- a/docs/diagrams/node.puml
+++ b/docs/diagrams/node.puml
@@ -1,0 +1,49 @@
+@startuml
+
+' user sends txn to node
+rectangle rest as "REST" {
+    usecase node0 as "Node" <<node>>
+    actor user0 as "User"
+    cloud txnpool0 as "Transaction Pool"
+
+    user0 --> node0: send signed\ntransaction\nvia REST
+    node0 --> txnpool0: add txn\nto pool
+}
+
+' p2p
+rectangle p2p {
+    usecase nodep2p1 as "Node" <<node>>
+    usecase nodep2p2 as "Node" <<node>>
+    cloud txnpoolp2p1 as "Transaction Pool"
+    cloud txnpoolp2p2 as "Transaction Pool"
+
+    nodep2p1 -> txnpoolp2p1
+    nodep2p2 -> txnpoolp2p2
+    nodep2p1 --> nodep2p2: request txnpool\nfrom peer node
+}
+
+' node creates block
+rectangle createblock as "Create Block" {
+    usecase node1 as "Node" <<node>>
+    cloud txnpool1 as "Transaction Pool"
+    rectangle newBlock1 as "New Block" <<block>>
+
+    node1 --> txnpool1
+    txnpool1 --> newBlock1: create new\nblock
+}
+
+' block is added to blockchain
+rectangle addblock as "Add Block to Blockchain" {
+    usecase node2 as "Node" <<node>>
+    rectangle newBlock2 as "New Block" <<block>>
+    cloud blockchain2 as "Blockchain"
+
+    newBlock2 .. node2
+    node2 --> blockchain2: add block\nto blockchain
+}
+
+rest -[hidden]-> p2p
+p2p -[hidden]-> createblock
+createblock -[hidden]-> addblock
+
+@enduml

--- a/docs/diagrams/p2p.puml
+++ b/docs/diagrams/p2p.puml
@@ -1,0 +1,13 @@
+@startuml
+
+cloud Nodes {
+    usecase node1
+    usecase node2
+    usecase node3
+
+    node1 <--> node2
+    node2 <--> node3
+    node1 <--> node3
+}
+
+@enduml

--- a/src/ledger/wallet.rs
+++ b/src/ledger/wallet.rs
@@ -18,6 +18,7 @@ use crate::{
     utils::signature::{BlockSignature, TxnSignature},
 };
 
+#[derive(Debug)]
 pub struct Wallet {
     keypair: KeyPair,
 }

--- a/src/node/error.rs
+++ b/src/node/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NodeError {
+    #[error("Blockchain not initialized.")]
+    InitBlockchain,
+    #[error("Wallet not initialized.")]
+    InitWallet,
+    #[error("Transaction pool not initialized.")]
+    InitTxnPool,
+}
+
+// #[deprecated(note = "Replace with Txn Map")]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,0 +1,127 @@
+// imports
+// local
+use crate::ledger::{blockchain::Blockchain, txn_pool::TxnPool, wallet::Wallet};
+pub mod error;
+use crate::node::error::NodeError;
+// submodule
+pub type Result<T> = std::result::Result<T, NodeError>;
+
+/// ## An instance of a `Node`.
+/// A node has a wallet, an instance of blockchain, and a transaction pool.
+/// Node will sync its blockchain ledger and transaction pool with its peers
+/// via the peer-to-peer network (p2p).
+///
+/// The struct is set up this way to:
+/// 1. Prioritize modularity;
+/// 1. Test components in isolation;
+/// 1. Decouple logic wherever possible;
+/// 1. Leverage the type-system for error handling;
+#[derive(Debug)]
+pub struct Node {
+    wallet: Option<Wallet>,
+    blockchain: Option<Blockchain>,
+    txn_pool: Option<TxnPool>,
+}
+
+impl Node {
+    /// ## Create new instance of Node.
+    ///
+    /// Internal values will be updated separately, because:
+    /// 1. There may be multiple ways to initialize a value (i.e. specific to a situation);
+    /// 1. Values may be updated asynchronously;
+    /// 1. It may not be necessary to initialize immediately.
+    pub fn new() -> Self {
+        let wallet = None;
+        let blockchain = None;
+        let txn_pool = None;
+
+        Self {
+            wallet,
+            blockchain,
+            txn_pool,
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////
+    ////////////////////////////// GETTERS //////////////////////////////
+    /// ## Get ref of wallet for this instance of the node.
+    pub fn wallet(&self) -> Result<&Wallet> {
+        match &self.wallet {
+            Some(w) => Ok(&w),
+            None => Err(NodeError::InitWallet),
+        }
+    }
+    /// ## Get ref of blockchain for this instance of the node.
+    pub fn blockchain(&self) -> Result<&Blockchain> {
+        match &self.blockchain {
+            Some(b) => Ok(&b),
+            None => Err(NodeError::InitBlockchain),
+        }
+    }
+    /// ## Get ref of transaction pool for this instance of the node.
+    pub fn txn_pool(&self) -> Result<&TxnPool> {
+        match &self.txn_pool {
+            Some(t) => Ok(&t),
+            None => Err(NodeError::InitTxnPool),
+        }
+    }
+    ////////////////////////////// GETTERS //////////////////////////////
+    /////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////
+    ////////////////////////////// SETTERS //////////////////////////////
+    /// ## Set the wallet for the node.
+    ///
+    /// Using a dedicated setter to standardize how the wallet gets updated.
+    ///
+    /// There will be more methods for initializing a wallet in the future.
+    fn set_wallet(&mut self, wallet: Wallet) -> Result<()> {
+        self.wallet = Some(wallet);
+
+        Ok(())
+    }
+    /// ## Set the wallet for the node with a filepath.
+    pub fn set_wallet_from_filepath(&mut self, filepath: &String) -> Result<()> {
+        let wallet = Wallet::new_from_file(filepath);
+
+        Ok(self.set_wallet(wallet)?)
+    }
+    /// ## INCOMPLETE Initialize the blockchain pulled from the peer to peer network.
+    ///
+    /// 1. Connect to p2p network
+    /// 1. Check with other nodes
+    /// 1. Fetch the hash of the blockchain
+    /// 1. Update blockchain if hash mismatch (get missing blocks)
+    /// Another setter for blockchain would be `set_blockchain_sync`
+    pub fn set_blockchain_init(&mut self) -> Result<()> {
+        todo!();
+        // self.blockchain = Some(Blockchain::new());
+
+        // Ok(())
+    }
+    /// ## INCOMPLETE Initialize the transaction pool pulled from the peer to peer network.
+    ///
+    /// 1. Connect to p2p network
+    /// 1. Check with other nodes
+    /// 1. Fetch the hash of the txn pool
+    /// 1. Update txn pool if hash mismatch (get missing txns)
+    /// Another setter for blockchain would be `set_txn_pool_sync`
+    pub fn set_txn_pool_init(&mut self) -> Result<()> {
+        todo!();
+        // self.blockchain = Some(Blockchain::new());
+
+        // Ok(())
+    }
+    ////////////////////////////// SETTERS //////////////////////////////
+    /////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////
+    /////////////////////////////// UTILS ///////////////////////////////
+    /////////////////////////////// UTILS ///////////////////////////////
+    /////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////
+    ///////////////////////////// VALIDATION ////////////////////////////
+    ///////////////////////////// VALIDATION ////////////////////////////
+    /////////////////////////////////////////////////////////////////////
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,6 +9,7 @@ use posbc::ledger::{
 };
 pub mod constants;
 pub mod fxns;
+pub use fxns::*;
 use constants::*;
 
 fn create_keypair_from_file(filepath: &String) -> KP {
@@ -25,6 +26,7 @@ fn create_keypair_from_file(filepath: &String) -> KP {
 pub struct UserInfo {
     pub kp: KP,
     pub wallet: Wallet,
+    pub filepath: String,
 }
 impl UserInfo {
     pub fn pbkey(&self) -> PbKey {
@@ -34,7 +36,11 @@ impl UserInfo {
 fn get_user_info(key_str: &String) -> UserInfo {
     let kp = create_keypair_from_file(key_str);
     let wallet = Wallet::new_from_kp(&kp);
-    UserInfo { kp, wallet }
+    UserInfo {
+        kp,
+        wallet,
+        filepath: key_str.to_owned(),
+    }
 }
 pub struct UsersInfo {
     pub main: UserInfo,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,3 @@
 pub mod accounts;
-pub mod ledger;
+pub mod common;
 pub mod node;
-pub mod utils;

--- a/tests/node/mod.rs
+++ b/tests/node/mod.rs
@@ -1,0 +1,34 @@
+// local
+use posbc::node::{Node, Result};
+// test
+use crate::common::fxns::init_blockchain_and_accounts;
+
+/// Test if the node is correctly using its environment to:
+/// 1. Connect to the peer to peer network
+/// 1. Load wallet correctly
+/// 1. Initialize its values correctly (blockchain, txn pool, wallet)
+#[test]
+fn init_node_pass() -> Result<()> {
+    let (users, _blockchain) = init_blockchain_and_accounts();
+
+    // initialize node
+    let mut node = Node::new();
+    // initialize wallet
+    node.set_wallet_from_filepath(&users.main.filepath)?;
+    assert_eq!(
+        &node.wallet()?.pbkey(),
+        &users.main.wallet.pbkey(),
+        "Wallet values not equal"
+    );
+
+    // @todo initialize p2p
+    // @todo initialize blockchain
+    // @todo initialize txn pool
+    Ok(())
+}
+
+// #[test]
+// #[should_panic]
+// fn init_node_fail() {
+//     let node = Node::new();
+// }


### PR DESCRIPTION
closes #77 

Create `node` dirs in `lib` and `tests`.
Create `Node` struct, with getters, setters, and init functions.
Create tests for initializing an instance of `Node`.
